### PR TITLE
Start server and database with docker compose

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,8 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+indent_style = space
+indent_size = 4
 
 [{Makefile,*.go}]
 indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ go.work
 
 # Build output
 docentre
+.cache/
 
 # Database data
 .db/

--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,11 @@
 # Go workspace file
 go.work
 
-# build output
-docentre 
+# Build output
+docentre
+
+# Database data
+.db/
 
 .idea/
 .vscode/
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
 FROM golang:1.22
 
+ARG UID=1000
+ARG GID=1000
+ARG USER=user
+
 RUN apt-get --no-install-recommends install -y \
 	make \
 	&& rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -g $GID $USER \
+    && useradd -u $UID -g $USER -s /bin/bash -m $USER
+
+USER $USER
+
+WORKDIR /home/$USER

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.22
+
+RUN apt-get --no-install-recommends install -y \
+	make \
+	&& rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ _DoCentre_, **Do**cument **Centre**, is a robust document management platform de
 
 ### Prerequisites
 
-- The _Go_ programming language (version 1.22 or later is recommended) is required to run the server. You can download and install Go from the [official website](https://go.dev/doc/install).
+- [Docker](https://docs.docker.com/get-docker/) is used to run the server and database in containers with uniform environments.
 
 ### Starting the Server
 
@@ -58,10 +58,10 @@ $ cd DoCentre
 $ cd DoCentre-main
 ```
 
-3. Run the server:
+3. Run the containers:
 
 ```console
-$ go run main.go
+$ docker compose up
 ```
 
 The server should now be running on `localhost:8080`:
@@ -69,23 +69,6 @@ The server should now be running on `localhost:8080`:
 ```console
 $ curl http://localhost:8080/health
 {"message":"health check success"}
-```
-
-
-## Dev Setup
-
-### data migrate with GORM
-
-```bash
-go run migrate/migrate.go
-```
-
-### CompileDaemon 
-[Very simple Compile Daemon for Go](https://github.com/githubnemo/CompileDaemon) \
-Watches your `.go` files in a directory and invokes `go build` if a file changed. 
-
-```bash
-CompileDaemon -command="./docentre"
 ```
 
 ## 🧾 API Endpoints <a name = "api"></a>
@@ -131,6 +114,7 @@ $ make test-coverage
 
 ### Prerequisites
 
+- The [Go](https://go.dev/doc/install) programming language (version 1.22 or later is recommended) is used to develop the server.
 - [Make](https://www.gnu.org/software/make/#download) is used to gather the required tools and commands for development.
 - [pre-commit](https://pre-commit.com/#install) is used to run checks before committing changes.
 
@@ -160,6 +144,20 @@ Targets:
   help            Show this help message
 
 ```
+
+### Docker Compose
+
+The `docker-compose.yml` file is used to run the server and database in containers, with the current directory mounted as a volume. The database files are stored in the `.db/` directory.
+
+Additionally, the server is configured to automatically reload when changes are made to the source code using [CompileDaemon](https://github.com/githubnemo/CompileDaemon).
+
+To start the server and database, use the following command:
+
+```console
+$ docker compose up
+```
+
+You can then develop the server on your local machine.
 
 ### Git Hooks
 

--- a/db-init/init.sql
+++ b/db-init/init.sql
@@ -1,0 +1,4 @@
+CREATE DATABASE IF NOT EXISTS `docentre`;
+
+CREATE USER 'my_user'@'localhost' IDENTIFIED BY 'my_password';
+GRANT ALL PRIVILEGES ON docentre.* TO 'my_user'@'localhost';

--- a/db-init/init.sql
+++ b/db-init/init.sql
@@ -1,4 +1,0 @@
-CREATE DATABASE IF NOT EXISTS `docentre`;
-
-CREATE USER 'my_user'@'localhost' IDENTIFIED BY 'my_password';
-GRANT ALL PRIVILEGES ON docentre.* TO 'my_user'@'localhost';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     working_dir: /home/user/docentre
     # As `depends_on` does not wait for the container to be ready,
     # we need to add a sleep command to ensure the database is ready before the server starts.
-    command: ["/bin/sh", "-c", "sleep 5 && go run ."]
+    command: ["/bin/sh", "-c", "sleep 5 && ./docker-entrypoint.sh"]
 
   db:
     image: mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,29 @@
 services:
-  server:
-    hostname: server
-    build:
-        context: .
-        args:
-          - UID=1000
-          - GID=1000
-          - USER=user
-    network_mode: host
-    depends_on:
-      - db
-    volumes:
-      - .:/home/user/docentre
-    working_dir: /home/user/docentre
-    # As `depends_on` does not wait for the container to be ready,
-    # we need to add a sleep command to ensure the database is ready before the server starts.
-    command: ["/bin/sh", "-c", "sleep 5 && ./docker-entrypoint.sh"]
+    server:
+        hostname: server
+        build:
+            context: .
+            args:
+                - UID=1000
+                - GID=1000
+                - USER=user
+        network_mode: host
+        depends_on:
+            - db
+        volumes:
+            - .:/home/user/docentre
+        working_dir: /home/user/docentre
+        # As `depends_on` does not wait for the container to be ready,
+        # we need to add a sleep command to ensure the database is ready before the server starts.
+        command: ["/bin/sh", "-c", "sleep 5 && ./docker-entrypoint.sh"]
 
-  db:
-    image: mysql
-    network_mode: host
-    environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_USER: my_user
-      MYSQL_PASSWORD: my_password
-      MYSQL_DATABASE: docentre
-    volumes:
-      - .db:/var/lib/mysql
-      # The init script under ./db-init will be executed when the container is first created
+    db:
+        image: mysql
+        network_mode: host
+        environment:
+            MYSQL_ROOT_PASSWORD: root
+            MYSQL_USER: my_user
+            MYSQL_PASSWORD: my_password
+            MYSQL_DATABASE: docentre
+        volumes:
+            - .db:/var/lib/mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,13 +9,13 @@ services:
                 - USER=user
         network_mode: host
         depends_on:
-            - db
+            db:
+                condition: service_healthy
         volumes:
             - .:/home/user/docentre
         working_dir: /home/user/docentre
-        # As `depends_on` does not wait for the container to be ready,
-        # we need to add a sleep command to ensure the database is ready before the server starts.
-        command: ["/bin/sh", "-c", "sleep 5 && ./docker-entrypoint.sh"]
+        entrypoint:
+            - ./docker-entrypoint.sh
 
     db:
         image: mysql
@@ -27,3 +27,9 @@ services:
             MYSQL_DATABASE: docentre
         volumes:
             - .db:/var/lib/mysql
+        healthcheck:
+            test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+            interval: 5s
+            timeout: 3s
+            retries: 30
+            start_period: 15s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,13 @@
 services:
   server:
     hostname: server
-    build: .
+    build:
+        context: .
+        args:
+          - UID=1000
+          - GID=1000
+          - USER=user
     network_mode: host
-    user: 1000:1000
     depends_on:
       - db
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  server:
+    hostname: server
+    build: .
+    network_mode: host
+    user: 1000:1000
+    depends_on:
+      - db
+    volumes:
+      - .:/home/user/docentre
+    working_dir: /home/user/docentre
+    # As `depends_on` does not wait for the container to be ready,
+    # we need to add a sleep command to ensure the database is ready before the server starts.
+    command: ["/bin/sh", "-c", "sleep 5 && go run ."]
+
+  db:
+    image: mysql
+    network_mode: host
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+    volumes:
+      - .db:/var/lib/mysql
+      # The init script under ./db-init will be executed when the container is first created.
+      - ./db-init:/docker-entrypoint-initdb.d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,9 @@ services:
     network_mode: host
     environment:
       MYSQL_ROOT_PASSWORD: root
+      MYSQL_USER: my_user
+      MYSQL_PASSWORD: my_password
+      MYSQL_DATABASE: docentre
     volumes:
       - .db:/var/lib/mysql
-      # The init script under ./db-init will be executed when the container is first created.
-      - ./db-init:/docker-entrypoint-initdb.d
+      # The init script under ./db-init will be executed when the container is first created

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,4 +3,4 @@
 set -eux
 
 go install github.com/githubnemo/CompileDaemon@latest &&
-    CompileDaemon -command="./docentre" -exclude-dir="\.*"
+    CompileDaemon -command="./docentre" -exclude-dir=".*"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+set -eux
+
+go install github.com/githubnemo/CompileDaemon@latest &&
+    CompileDaemon -command="./docentre" -exclude-dir="\.*"


### PR DESCRIPTION
# What's the Problem?

Configuring the database can be cumbersome, so we're leveraging Docker and Docker Compose to streamline the process.

# How to Verify?

Follow the instructions in the "Starting the Server" section of the README. After starting the server, it should be able to respond to the health check.

> [!note]
> 1. I encountered difficulty connecting the server to the database even with Docker Compose. Setting `network_mode: host` seems to be critical for the server to access the port served by the database.
> 2. The "Dev Setup" section of the README seems to be outdated and is removed.