### PR TITLE
Add API documentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,17 +76,6 @@ $ curl http://localhost:8080/health
 There's also an API documentation available at `localhost:8080/swagger/index.html`.
 Open the URL in your browser to view the API documentation.
 
-The following is a brief overview of the available endpoints:
-
-### Health Check
-
-- URL: `/health`
-- Method: `GET`
-- Description: Check the health of the server.
-- Response:
-  - `200 OK`: `{"message":"health check success"}`
-  - `4xx` or `5xx`
-
 ## 🔧 Running the Tests <a name = "tests"></a>
 
 _DoCentre_ uses the `testing` package in _Go_ to write tests.

--- a/controllers/DocumentController.go
+++ b/controllers/DocumentController.go
@@ -8,28 +8,49 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+type createDocumentRequest struct {
+	AuthorID uint `json:"author_id" binding:"required" example:"1"`
+}
+type createDocumentInvalidResponse struct {
+	Error string `json:"error" example:"Invalid request body"`
+}
+type createDocumentFailedResponse struct {
+	Error string `json:"error" example:"Failed to create document"`
+}
+type createDocumentSuccessResponse struct {
+	DocumentID uint `json:"document_id" example:"10"`
+}
+
+// @Summary Create document
+// @Description Create a new document that belongs to the author; the author has to be a existing user.
+// @Tags document
+// @Accept json
+// @Produce json
+// @Param body body createDocumentRequest true " "
+// @Success 200 {object} createDocumentSuccessResponse
+// @Failure 400 {object} createDocumentInvalidResponse
+// @Failure 500 {object} createDocumentFailedResponse
+// @Router /document [post]
 func CreateDocument(c *gin.Context) {
-	var body struct {
-		AuthorID uint `json:"author_id" binding:"required"`
-	}
+	var body createDocumentRequest
 	err := c.BindJSON(&body)
 	if err != nil {
 		log.Default().Println(err)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "Invalid request body",
+		c.JSON(http.StatusBadRequest, createDocumentInvalidResponse{
+			Error: "Invalid request body",
 		})
 		return
 	}
 
 	doc, err := services.CreateDocument(body.AuthorID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "Failed to create document",
+		c.JSON(http.StatusInternalServerError, createDocumentFailedResponse{
+			Error: "Failed to create document",
 		})
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
-		"document_id": doc.ID,
+	c.JSON(http.StatusOK, createDocumentSuccessResponse{
+		DocumentID: doc.ID,
 	})
 }

--- a/controllers/DocumentController.go
+++ b/controllers/DocumentController.go
@@ -8,35 +8,35 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type createDocumentRequest struct {
-	AuthorID uint `json:"author_id" binding:"required" example:"1"`
-}
-type createDocumentInvalidResponse struct {
-	Error string `json:"error" example:"Invalid request body"`
-}
-type createDocumentFailedResponse struct {
-	Error string `json:"error" example:"Failed to create document"`
-}
-type createDocumentSuccessResponse struct {
-	DocumentID uint `json:"document_id" example:"10"`
-}
-
 // @Summary Create document
 // @Description Create a new document that belongs to the author; the author has to be a existing user.
 // @Tags document
 // @Accept json
 // @Produce json
-// @Param body body createDocumentRequest true " "
-// @Success 200 {object} createDocumentSuccessResponse
-// @Failure 400 {object} createDocumentInvalidResponse
-// @Failure 500 {object} createDocumentFailedResponse
+// @Param body body controllers.CreateDocument.requestBody true " "
+// @Success 200 {object} controllers.CreateDocument.successResponseBody
+// @Failure 400 {object} controllers.CreateDocument.invalidResponseBody
+// @Failure 500 {object} controllers.CreateDocument.failedResponseBody
 // @Router /document [post]
 func CreateDocument(c *gin.Context) {
-	var body createDocumentRequest
+	type requestBody struct {
+		AuthorID uint `json:"author_id" binding:"required" example:"1"`
+	}
+	type invalidResponseBody struct {
+		Error string `json:"error" example:"Invalid request body"`
+	}
+	type failedResponseBody struct {
+		Error string `json:"error" example:"Failed to create document"`
+	}
+	type successResponseBody struct {
+		DocumentID uint `json:"document_id" example:"10"`
+	}
+
+	var body requestBody
 	err := c.BindJSON(&body)
 	if err != nil {
 		log.Default().Println(err)
-		c.JSON(http.StatusBadRequest, createDocumentInvalidResponse{
+		c.JSON(http.StatusBadRequest, invalidResponseBody{
 			Error: "Invalid request body",
 		})
 		return
@@ -44,13 +44,13 @@ func CreateDocument(c *gin.Context) {
 
 	doc, err := services.CreateDocument(body.AuthorID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, createDocumentFailedResponse{
+		c.JSON(http.StatusInternalServerError, failedResponseBody{
 			Error: "Failed to create document",
 		})
 		return
 	}
 
-	c.JSON(http.StatusOK, createDocumentSuccessResponse{
+	c.JSON(http.StatusOK, successResponseBody{
 		DocumentID: doc.ID,
 	})
 }

--- a/controllers/DocumentController.go
+++ b/controllers/DocumentController.go
@@ -10,7 +10,7 @@ import (
 
 // @Summary Create document
 // @Description Create a new document that belongs to the author; the author has to be a existing user.
-// @Tags document
+// @Tags Document
 // @Accept json
 // @Produce json
 // @Param body body controllers.CreateDocument.requestBody true " "

--- a/controllers/UserController.go
+++ b/controllers/UserController.go
@@ -61,20 +61,39 @@ func UserCreate(c *gin.Context) {
 	})
 }
 
+// @Summary Login a user
+// @Description Login a user with username and password.
+// @Tags User
+// @Accept json
+// @Produce json
+// @Param body body controllers.UserLogin.requestBody true " "
+// @Success 200 {object} controllers.UserLogin.successResponseBody
+// @Failure 404 {object} controllers.UserLogin.userNotFoundResponseBody
+// @Router /user/login [post]
 func UserLogin(c *gin.Context) {
-	var body struct {
-		Username string `json:"username" binding:"required"`
-		Password string `json:"password" binding:"required"`
+	type requestBody struct {
+		Username string `json:"username" binding:"required" example:"username"`
+		Password string `json:"password" binding:"required" example:"password"`
+	}
+	type userNotFoundResponseBody struct {
+		// Should always be nil.
+		// XXX: Consider removing the field; also swaggo fails to generate example with null value.
+		User *UserDto `json:"user"`
+		Msg  string   `json:"msg" example:"User not found"`
+	}
+	type successResponseBody struct {
+		User UserDto `json:"user"`
 	}
 
+	var body requestBody
 	c.Bind(&body)
 
 	user, err := services.UserLogin(body.Username, body.Password)
 	if err != nil {
 		log.Default().Println(err)
-		c.JSON(404, gin.H{
-			"user": nil,
-			"msg":  "User not found",
+		c.JSON(404, userNotFoundResponseBody{
+			User: nil,
+			Msg:  "User not found",
 		})
 		return
 	}
@@ -86,8 +105,8 @@ func UserLogin(c *gin.Context) {
 		Identity: user.Identity,
 	}
 
-	c.JSON(200, gin.H{
-		"user": userDto,
+	c.JSON(200, successResponseBody{
+		User: userDto,
 	})
 }
 

--- a/controllers/UserController.go
+++ b/controllers/UserController.go
@@ -22,7 +22,7 @@ type UserDto struct {
 // @Param body body controllers.UserCreate.requestBody true " "
 // @Success 200 {object} controllers.UserCreate.successResponseBody
 // @Failure 400 {object} controllers.UserCreate.existedResponseBody
-// @Router /user/create [post]
+// @Router /user [post]
 func UserCreate(c *gin.Context) {
 	type requestBody struct {
 		Username string `json:"username" binding:"required" example:"username"`
@@ -69,7 +69,7 @@ func UserCreate(c *gin.Context) {
 // @Param body body controllers.UserLogin.requestBody true " "
 // @Success 200 {object} controllers.UserLogin.successResponseBody
 // @Failure 404 {object} controllers.UserLogin.userNotFoundResponseBody
-// @Router /user/login [post]
+// @Router /login [post]
 func UserLogin(c *gin.Context) {
 	type requestBody struct {
 		Username string `json:"username" binding:"required" example:"username"`
@@ -118,7 +118,7 @@ func UserLogin(c *gin.Context) {
 // @Param body body controllers.GetUsersByUsername.requestBody true " "
 // @Success 200 {object} controllers.GetUsersByUsername.successResponseBody
 // @Failure 200 {object} controllers.GetUsersByUsername.usersNotFoundResponseBody
-// @Router /user/get [post]
+// @Router /users [post]
 func GetUsersByUsername(c *gin.Context) {
 	type requestBody struct {
 		Username string `json:"username" binding:"required" example:"username"`

--- a/controllers/UserController.go
+++ b/controllers/UserController.go
@@ -14,36 +14,36 @@ type UserDto struct {
 	Identity string `json:"identity" example:"user"`
 }
 
-type userCreateRequest struct {
-	Username string `json:"username" binding:"required" example:"username"`
-	Email    string `json:"email" binding:"required" example:"email@mail.com"`
-	Password string `json:"password" binding:"required" example:"password"`
-}
-type userCreateExistedResponse struct {
-	Msg string `json:"msg" example:"User/Email already exists"`
-}
-type userCreateSuccessResponse struct {
-	User UserDto `json:"user"`
-}
-
 // @Summary Create a user
 // @Description Create a new user; the user will be created with the identity "user".
 // @Tags User
 // @Accept json
 // @Produce json
-// @Param body body userCreateRequest true " "
-// @Success 200 {object} userCreateSuccessResponse
-// @Failure 400 {object} userCreateExistedResponse
+// @Param body body controllers.UserCreate.requestBody true " "
+// @Success 200 {object} controllers.UserCreate.successResponseBody
+// @Failure 400 {object} controllers.UserCreate.existedResponseBody
 // @Router /user/create [post]
 func UserCreate(c *gin.Context) {
-	var body userCreateRequest
+	type requestBody struct {
+		Username string `json:"username" binding:"required" example:"username"`
+		Email    string `json:"email" binding:"required" example:"email@mail.com"`
+		Password string `json:"password" binding:"required" example:"password"`
+	}
+	type existedResponseBody struct {
+		Msg string `json:"msg" example:"User/Email already exists"`
+	}
+	type successResponseBody struct {
+		User UserDto `json:"user"`
+	}
+
+	var body requestBody
 	c.Bind(&body)
 
 	user, err := services.UserCreate(body.Username, body.Email, body.Password)
 	if err != nil {
 		log.Default().Println(err)
 		c.Status(400)
-		c.JSON(400, userCreateExistedResponse{
+		c.JSON(400, existedResponseBody{
 			Msg: "User/Email already exists",
 		})
 		return
@@ -56,7 +56,7 @@ func UserCreate(c *gin.Context) {
 		Identity: user.Identity,
 	}
 
-	c.JSON(200, userCreateSuccessResponse{
+	c.JSON(200, successResponseBody{
 		User: userDto,
 	})
 }

--- a/controllers/UserController.go
+++ b/controllers/UserController.go
@@ -8,26 +8,43 @@ import (
 )
 
 type UserDto struct {
-	ID       uint   `json:"id"`
-	Username string `json:"username"`
-	Email    string `json:"email"`
-	Identity string `json:"identity"`
+	ID       uint   `json:"id" example:"1"`
+	Username string `json:"username" example:"username"`
+	Email    string `json:"email" example:"email@mail.com"`
+	Identity string `json:"identity" example:"user"`
 }
 
+type userCreateRequest struct {
+	Username string `json:"username" binding:"required" example:"username"`
+	Email    string `json:"email" binding:"required" example:"email@mail.com"`
+	Password string `json:"password" binding:"required" example:"password"`
+}
+type userCreateExistedResponse struct {
+	Msg string `json:"msg" example:"User/Email already exists"`
+}
+type userCreateSuccessResponse struct {
+	User UserDto `json:"user"`
+}
+
+// @Summary Create a user
+// @Description Create a new user; the user will be created with the identity "user".
+// @Tags User
+// @Accept json
+// @Produce json
+// @Param body body userCreateRequest true " "
+// @Success 200 {object} userCreateSuccessResponse
+// @Failure 400 {object} userCreateExistedResponse
+// @Router /user/create [post]
 func UserCreate(c *gin.Context) {
-	var body struct {
-		Username string `json:"username" binding:"required"`
-		Email    string `json:"email" binding:"required"`
-		Password string `json:"password" binding:"required"`
-	}
+	var body userCreateRequest
 	c.Bind(&body)
 
 	user, err := services.UserCreate(body.Username, body.Email, body.Password)
 	if err != nil {
 		log.Default().Println(err)
 		c.Status(400)
-		c.JSON(400, gin.H{
-			"msg": "User/Email already exists",
+		c.JSON(400, userCreateExistedResponse{
+			Msg: "User/Email already exists",
 		})
 		return
 	}
@@ -39,8 +56,8 @@ func UserCreate(c *gin.Context) {
 		Identity: user.Identity,
 	}
 
-	c.JSON(200, gin.H{
-		"user": userDto,
+	c.JSON(200, userCreateSuccessResponse{
+		User: userDto,
 	})
 }
 

--- a/controllers/UserController.go
+++ b/controllers/UserController.go
@@ -110,19 +110,38 @@ func UserLogin(c *gin.Context) {
 	})
 }
 
+// @Summary Get users by username
+// @Description Get users with the same given username.
+// @Tags User
+// @Accept json
+// @Produce json
+// @Param body body controllers.GetUsersByUsername.requestBody true " "
+// @Success 200 {object} controllers.GetUsersByUsername.successResponseBody
+// @Failure 200 {object} controllers.GetUsersByUsername.usersNotFoundResponseBody
+// @Router /user/get [post]
 func GetUsersByUsername(c *gin.Context) {
-	var body struct {
-		Username string `json:"username" binding:"required"`
+	type requestBody struct {
+		Username string `json:"username" binding:"required" example:"username"`
+	}
+	type usersNotFoundResponseBody struct {
+		// Should always be empty.
+		// XXX: Consider removing the field.
+		Users []UserDto `json:"users"`
+		Msg   string    `json:"msg" example:"Users not found"`
+	}
+	type successResponseBody struct {
+		Users []UserDto `json:"users"`
 	}
 
+	var body requestBody
 	c.Bind(&body)
 
 	users, err := services.GetUsersByUsername(body.Username)
 	if err != nil {
 		log.Default().Println(err)
-		c.JSON(200, gin.H{
-			"users": []UserDto{},
-			"msg":   "Users not found",
+		c.JSON(200, usersNotFoundResponseBody{
+			Users: []UserDto{},
+			Msg:   "Users not found",
 		})
 		return
 	}
@@ -139,7 +158,7 @@ func GetUsersByUsername(c *gin.Context) {
 		usersDto = append(usersDto, userDto)
 	}
 
-	c.JSON(200, gin.H{
-		"users": usersDto,
+	c.JSON(200, successResponseBody{
+		Users: usersDto,
 	})
 }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -83,7 +83,47 @@ const docTemplate = `{
                 }
             }
         },
-        "/user/create": {
+        "/login": {
+            "post": {
+                "description": "Login a user with username and password.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Login a user",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.UserLogin.requestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.UserLogin.successResponseBody"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.UserLogin.userNotFoundResponseBody"
+                        }
+                    }
+                }
+            }
+        },
+        "/user": {
             "post": {
                 "description": "Create a new user; the user will be created with the identity \"user\".",
                 "consumes": [
@@ -123,7 +163,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/user/get": {
+        "/users": {
             "post": {
                 "description": "Get users with the same given username.",
                 "consumes": [
@@ -152,46 +192,6 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/controllers.GetUsersByUsername.usersNotFoundResponseBody"
-                        }
-                    }
-                }
-            }
-        },
-        "/user/login": {
-            "post": {
-                "description": "Login a user with username and password.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "User"
-                ],
-                "summary": "Login a user",
-                "parameters": [
-                    {
-                        "description": " ",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/controllers.UserLogin.requestBody"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.UserLogin.successResponseBody"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.UserLogin.userNotFoundResponseBody"
                         }
                     }
                 }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -82,9 +82,70 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/user/create": {
+            "post": {
+                "description": "Create a new user; the user will be created with the identity \"user\".",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Create a user",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.userCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.userCreateSuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.userCreateExistedResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "controllers.UserDto": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "example": "email@mail.com"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "identity": {
+                    "type": "string",
+                    "example": "user"
+                },
+                "username": {
+                    "type": "string",
+                    "example": "username"
+                }
+            }
+        },
         "controllers.createDocumentFailedResponse": {
             "type": "object",
             "properties": {
@@ -121,6 +182,45 @@ const docTemplate = `{
                 "document_id": {
                     "type": "integer",
                     "example": 10
+                }
+            }
+        },
+        "controllers.userCreateExistedResponse": {
+            "type": "object",
+            "properties": {
+                "msg": {
+                    "type": "string",
+                    "example": "User/Email already exists"
+                }
+            }
+        },
+        "controllers.userCreateRequest": {
+            "type": "object",
+            "required": [
+                "email",
+                "password",
+                "username"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "example": "email@mail.com"
+                },
+                "password": {
+                    "type": "string",
+                    "example": "password"
+                },
+                "username": {
+                    "type": "string",
+                    "example": "username"
+                }
+            }
+        },
+        "controllers.userCreateSuccessResponse": {
+            "type": "object",
+            "properties": {
+                "user": {
+                    "$ref": "#/definitions/controllers.UserDto"
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -122,6 +122,46 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/user/login": {
+            "post": {
+                "description": "Login a user with username and password.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Login a user",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.UserLogin.requestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.UserLogin.successResponseBody"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.UserLogin.userNotFoundResponseBody"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -221,6 +261,48 @@ const docTemplate = `{
                 "username": {
                     "type": "string",
                     "example": "username"
+                }
+            }
+        },
+        "controllers.UserLogin.requestBody": {
+            "type": "object",
+            "required": [
+                "password",
+                "username"
+            ],
+            "properties": {
+                "password": {
+                    "type": "string",
+                    "example": "password"
+                },
+                "username": {
+                    "type": "string",
+                    "example": "username"
+                }
+            }
+        },
+        "controllers.UserLogin.successResponseBody": {
+            "type": "object",
+            "properties": {
+                "user": {
+                    "$ref": "#/definitions/controllers.UserDto"
+                }
+            }
+        },
+        "controllers.UserLogin.userNotFoundResponseBody": {
+            "type": "object",
+            "properties": {
+                "msg": {
+                    "type": "string",
+                    "example": "User not found"
+                },
+                "user": {
+                    "description": "Should always be nil.\nTODO: Should be removed; also swaggo fails to generate example with null value.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/controllers.UserDto"
+                        }
+                    ]
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -35,7 +35,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controllers.createDocumentRequest"
+                            "$ref": "#/definitions/controllers.CreateDocument.requestBody"
                         }
                     }
                 ],
@@ -43,19 +43,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controllers.createDocumentSuccessResponse"
+                            "$ref": "#/definitions/controllers.CreateDocument.successResponseBody"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/controllers.createDocumentInvalidResponse"
+                            "$ref": "#/definitions/controllers.CreateDocument.invalidResponseBody"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controllers.createDocumentFailedResponse"
+                            "$ref": "#/definitions/controllers.CreateDocument.failedResponseBody"
                         }
                     }
                 }
@@ -77,7 +77,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/router.healthResponse"
+                            "$ref": "#/definitions/router.CheckHealth.responseBody"
                         }
                     }
                 }
@@ -103,7 +103,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controllers.userCreateRequest"
+                            "$ref": "#/definitions/controllers.UserCreate.requestBody"
                         }
                     }
                 ],
@@ -111,13 +111,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controllers.userCreateSuccessResponse"
+                            "$ref": "#/definitions/controllers.UserCreate.successResponseBody"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/controllers.userCreateExistedResponse"
+                            "$ref": "#/definitions/controllers.UserCreate.existedResponseBody"
                         }
                     }
                 }
@@ -125,28 +125,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "controllers.UserDto": {
-            "type": "object",
-            "properties": {
-                "email": {
-                    "type": "string",
-                    "example": "email@mail.com"
-                },
-                "id": {
-                    "type": "integer",
-                    "example": 1
-                },
-                "identity": {
-                    "type": "string",
-                    "example": "user"
-                },
-                "username": {
-                    "type": "string",
-                    "example": "username"
-                }
-            }
-        },
-        "controllers.createDocumentFailedResponse": {
+        "controllers.CreateDocument.failedResponseBody": {
             "type": "object",
             "properties": {
                 "error": {
@@ -155,7 +134,7 @@ const docTemplate = `{
                 }
             }
         },
-        "controllers.createDocumentInvalidResponse": {
+        "controllers.CreateDocument.invalidResponseBody": {
             "type": "object",
             "properties": {
                 "error": {
@@ -164,7 +143,7 @@ const docTemplate = `{
                 }
             }
         },
-        "controllers.createDocumentRequest": {
+        "controllers.CreateDocument.requestBody": {
             "type": "object",
             "required": [
                 "author_id"
@@ -176,7 +155,7 @@ const docTemplate = `{
                 }
             }
         },
-        "controllers.createDocumentSuccessResponse": {
+        "controllers.CreateDocument.successResponseBody": {
             "type": "object",
             "properties": {
                 "document_id": {
@@ -185,7 +164,7 @@ const docTemplate = `{
                 }
             }
         },
-        "controllers.userCreateExistedResponse": {
+        "controllers.UserCreate.existedResponseBody": {
             "type": "object",
             "properties": {
                 "msg": {
@@ -194,7 +173,7 @@ const docTemplate = `{
                 }
             }
         },
-        "controllers.userCreateRequest": {
+        "controllers.UserCreate.requestBody": {
             "type": "object",
             "required": [
                 "email",
@@ -216,7 +195,7 @@ const docTemplate = `{
                 }
             }
         },
-        "controllers.userCreateSuccessResponse": {
+        "controllers.UserCreate.successResponseBody": {
             "type": "object",
             "properties": {
                 "user": {
@@ -224,7 +203,28 @@ const docTemplate = `{
                 }
             }
         },
-        "router.healthResponse": {
+        "controllers.UserDto": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "example": "email@mail.com"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "identity": {
+                    "type": "string",
+                    "example": "user"
+                },
+                "username": {
+                    "type": "string",
+                    "example": "username"
+                }
+            }
+        },
+        "router.CheckHealth.responseBody": {
             "type": "object",
             "properties": {
                 "message": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15,6 +15,52 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/document": {
+            "post": {
+                "description": "Create a new document that belongs to the author; the author has to be a existing user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "document"
+                ],
+                "summary": "Create document",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.createDocumentRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.createDocumentSuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.createDocumentInvalidResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.createDocumentFailedResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "consumes": [
@@ -31,7 +77,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.healthResponse"
+                            "$ref": "#/definitions/router.healthResponse"
                         }
                     }
                 }
@@ -39,7 +85,46 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "main.healthResponse": {
+        "controllers.createDocumentFailedResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Failed to create document"
+                }
+            }
+        },
+        "controllers.createDocumentInvalidResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Invalid request body"
+                }
+            }
+        },
+        "controllers.createDocumentRequest": {
+            "type": "object",
+            "required": [
+                "author_id"
+            ],
+            "properties": {
+                "author_id": {
+                    "type": "integer",
+                    "example": 1
+                }
+            }
+        },
+        "controllers.createDocumentSuccessResponse": {
+            "type": "object",
+            "properties": {
+                "document_id": {
+                    "type": "integer",
+                    "example": 10
+                }
+            }
+        },
+        "router.healthResponse": {
             "type": "object",
             "properties": {
                 "message": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -25,7 +25,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "document"
+                    "Document"
                 ],
                 "summary": "Create document",
                 "parameters": [
@@ -70,7 +70,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "health"
+                    "Health"
                 ],
                 "summary": "Check health",
                 "responses": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -123,6 +123,40 @@ const docTemplate = `{
                 }
             }
         },
+        "/user/get": {
+            "post": {
+                "description": "Get users with the same given username.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Get users by username",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetUsersByUsername.requestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetUsersByUsername.usersNotFoundResponseBody"
+                        }
+                    }
+                }
+            }
+        },
         "/user/login": {
             "post": {
                 "description": "Login a user with username and password.",
@@ -201,6 +235,45 @@ const docTemplate = `{
                 "document_id": {
                     "type": "integer",
                     "example": 10
+                }
+            }
+        },
+        "controllers.GetUsersByUsername.requestBody": {
+            "type": "object",
+            "required": [
+                "username"
+            ],
+            "properties": {
+                "username": {
+                    "type": "string",
+                    "example": "username"
+                }
+            }
+        },
+        "controllers.GetUsersByUsername.successResponseBody": {
+            "type": "object",
+            "properties": {
+                "users": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.UserDto"
+                    }
+                }
+            }
+        },
+        "controllers.GetUsersByUsername.usersNotFoundResponseBody": {
+            "type": "object",
+            "properties": {
+                "msg": {
+                    "type": "string",
+                    "example": "Users not found"
+                },
+                "users": {
+                    "description": "Should always be empty.\nXXX: Consider removing the field.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.UserDto"
+                    }
                 }
             }
         },
@@ -297,7 +370,7 @@ const docTemplate = `{
                     "example": "User not found"
                 },
                 "user": {
-                    "description": "Should always be nil.\nTODO: Should be removed; also swaggo fails to generate example with null value.",
+                    "description": "Should always be nil.\nXXX: Consider removing the field; also swaggo fails to generate example with null value.",
                     "allOf": [
                         {
                             "$ref": "#/definitions/controllers.UserDto"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -112,6 +112,40 @@
                 }
             }
         },
+        "/user/get": {
+            "post": {
+                "description": "Get users with the same given username.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Get users by username",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetUsersByUsername.requestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetUsersByUsername.usersNotFoundResponseBody"
+                        }
+                    }
+                }
+            }
+        },
         "/user/login": {
             "post": {
                 "description": "Login a user with username and password.",
@@ -190,6 +224,45 @@
                 "document_id": {
                     "type": "integer",
                     "example": 10
+                }
+            }
+        },
+        "controllers.GetUsersByUsername.requestBody": {
+            "type": "object",
+            "required": [
+                "username"
+            ],
+            "properties": {
+                "username": {
+                    "type": "string",
+                    "example": "username"
+                }
+            }
+        },
+        "controllers.GetUsersByUsername.successResponseBody": {
+            "type": "object",
+            "properties": {
+                "users": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.UserDto"
+                    }
+                }
+            }
+        },
+        "controllers.GetUsersByUsername.usersNotFoundResponseBody": {
+            "type": "object",
+            "properties": {
+                "msg": {
+                    "type": "string",
+                    "example": "Users not found"
+                },
+                "users": {
+                    "description": "Should always be empty.\nXXX: Consider removing the field.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.UserDto"
+                    }
                 }
             }
         },
@@ -286,7 +359,7 @@
                     "example": "User not found"
                 },
                 "user": {
-                    "description": "Should always be nil.\nTODO: Should be removed; also swaggo fails to generate example with null value.",
+                    "description": "Should always be nil.\nXXX: Consider removing the field; also swaggo fails to generate example with null value.",
                     "allOf": [
                         {
                             "$ref": "#/definitions/controllers.UserDto"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -14,7 +14,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "document"
+                    "Document"
                 ],
                 "summary": "Create document",
                 "parameters": [
@@ -59,7 +59,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "health"
+                    "Health"
                 ],
                 "summary": "Check health",
                 "responses": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -24,7 +24,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controllers.createDocumentRequest"
+                            "$ref": "#/definitions/controllers.CreateDocument.requestBody"
                         }
                     }
                 ],
@@ -32,19 +32,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controllers.createDocumentSuccessResponse"
+                            "$ref": "#/definitions/controllers.CreateDocument.successResponseBody"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/controllers.createDocumentInvalidResponse"
+                            "$ref": "#/definitions/controllers.CreateDocument.invalidResponseBody"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controllers.createDocumentFailedResponse"
+                            "$ref": "#/definitions/controllers.CreateDocument.failedResponseBody"
                         }
                     }
                 }
@@ -66,7 +66,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/router.healthResponse"
+                            "$ref": "#/definitions/router.CheckHealth.responseBody"
                         }
                     }
                 }
@@ -92,7 +92,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controllers.userCreateRequest"
+                            "$ref": "#/definitions/controllers.UserCreate.requestBody"
                         }
                     }
                 ],
@@ -100,13 +100,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controllers.userCreateSuccessResponse"
+                            "$ref": "#/definitions/controllers.UserCreate.successResponseBody"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/controllers.userCreateExistedResponse"
+                            "$ref": "#/definitions/controllers.UserCreate.existedResponseBody"
                         }
                     }
                 }
@@ -114,28 +114,7 @@
         }
     },
     "definitions": {
-        "controllers.UserDto": {
-            "type": "object",
-            "properties": {
-                "email": {
-                    "type": "string",
-                    "example": "email@mail.com"
-                },
-                "id": {
-                    "type": "integer",
-                    "example": 1
-                },
-                "identity": {
-                    "type": "string",
-                    "example": "user"
-                },
-                "username": {
-                    "type": "string",
-                    "example": "username"
-                }
-            }
-        },
-        "controllers.createDocumentFailedResponse": {
+        "controllers.CreateDocument.failedResponseBody": {
             "type": "object",
             "properties": {
                 "error": {
@@ -144,7 +123,7 @@
                 }
             }
         },
-        "controllers.createDocumentInvalidResponse": {
+        "controllers.CreateDocument.invalidResponseBody": {
             "type": "object",
             "properties": {
                 "error": {
@@ -153,7 +132,7 @@
                 }
             }
         },
-        "controllers.createDocumentRequest": {
+        "controllers.CreateDocument.requestBody": {
             "type": "object",
             "required": [
                 "author_id"
@@ -165,7 +144,7 @@
                 }
             }
         },
-        "controllers.createDocumentSuccessResponse": {
+        "controllers.CreateDocument.successResponseBody": {
             "type": "object",
             "properties": {
                 "document_id": {
@@ -174,7 +153,7 @@
                 }
             }
         },
-        "controllers.userCreateExistedResponse": {
+        "controllers.UserCreate.existedResponseBody": {
             "type": "object",
             "properties": {
                 "msg": {
@@ -183,7 +162,7 @@
                 }
             }
         },
-        "controllers.userCreateRequest": {
+        "controllers.UserCreate.requestBody": {
             "type": "object",
             "required": [
                 "email",
@@ -205,7 +184,7 @@
                 }
             }
         },
-        "controllers.userCreateSuccessResponse": {
+        "controllers.UserCreate.successResponseBody": {
             "type": "object",
             "properties": {
                 "user": {
@@ -213,7 +192,28 @@
                 }
             }
         },
-        "router.healthResponse": {
+        "controllers.UserDto": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "example": "email@mail.com"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "identity": {
+                    "type": "string",
+                    "example": "user"
+                },
+                "username": {
+                    "type": "string",
+                    "example": "username"
+                }
+            }
+        },
+        "router.CheckHealth.responseBody": {
             "type": "object",
             "properties": {
                 "message": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4,6 +4,52 @@
         "contact": {}
     },
     "paths": {
+        "/document": {
+            "post": {
+                "description": "Create a new document that belongs to the author; the author has to be a existing user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "document"
+                ],
+                "summary": "Create document",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.createDocumentRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.createDocumentSuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.createDocumentInvalidResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.createDocumentFailedResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "consumes": [
@@ -20,7 +66,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.healthResponse"
+                            "$ref": "#/definitions/router.healthResponse"
                         }
                     }
                 }
@@ -28,7 +74,46 @@
         }
     },
     "definitions": {
-        "main.healthResponse": {
+        "controllers.createDocumentFailedResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Failed to create document"
+                }
+            }
+        },
+        "controllers.createDocumentInvalidResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Invalid request body"
+                }
+            }
+        },
+        "controllers.createDocumentRequest": {
+            "type": "object",
+            "required": [
+                "author_id"
+            ],
+            "properties": {
+                "author_id": {
+                    "type": "integer",
+                    "example": 1
+                }
+            }
+        },
+        "controllers.createDocumentSuccessResponse": {
+            "type": "object",
+            "properties": {
+                "document_id": {
+                    "type": "integer",
+                    "example": 10
+                }
+            }
+        },
+        "router.healthResponse": {
             "type": "object",
             "properties": {
                 "message": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -71,9 +71,70 @@
                     }
                 }
             }
+        },
+        "/user/create": {
+            "post": {
+                "description": "Create a new user; the user will be created with the identity \"user\".",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Create a user",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.userCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.userCreateSuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.userCreateExistedResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "controllers.UserDto": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "example": "email@mail.com"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "identity": {
+                    "type": "string",
+                    "example": "user"
+                },
+                "username": {
+                    "type": "string",
+                    "example": "username"
+                }
+            }
+        },
         "controllers.createDocumentFailedResponse": {
             "type": "object",
             "properties": {
@@ -110,6 +171,45 @@
                 "document_id": {
                     "type": "integer",
                     "example": 10
+                }
+            }
+        },
+        "controllers.userCreateExistedResponse": {
+            "type": "object",
+            "properties": {
+                "msg": {
+                    "type": "string",
+                    "example": "User/Email already exists"
+                }
+            }
+        },
+        "controllers.userCreateRequest": {
+            "type": "object",
+            "required": [
+                "email",
+                "password",
+                "username"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "example": "email@mail.com"
+                },
+                "password": {
+                    "type": "string",
+                    "example": "password"
+                },
+                "username": {
+                    "type": "string",
+                    "example": "username"
+                }
+            }
+        },
+        "controllers.userCreateSuccessResponse": {
+            "type": "object",
+            "properties": {
+                "user": {
+                    "$ref": "#/definitions/controllers.UserDto"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -72,7 +72,47 @@
                 }
             }
         },
-        "/user/create": {
+        "/login": {
+            "post": {
+                "description": "Login a user with username and password.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Login a user",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.UserLogin.requestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.UserLogin.successResponseBody"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.UserLogin.userNotFoundResponseBody"
+                        }
+                    }
+                }
+            }
+        },
+        "/user": {
             "post": {
                 "description": "Create a new user; the user will be created with the identity \"user\".",
                 "consumes": [
@@ -112,7 +152,7 @@
                 }
             }
         },
-        "/user/get": {
+        "/users": {
             "post": {
                 "description": "Get users with the same given username.",
                 "consumes": [
@@ -141,46 +181,6 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/controllers.GetUsersByUsername.usersNotFoundResponseBody"
-                        }
-                    }
-                }
-            }
-        },
-        "/user/login": {
-            "post": {
-                "description": "Login a user with username and password.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "User"
-                ],
-                "summary": "Login a user",
-                "parameters": [
-                    {
-                        "description": " ",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/controllers.UserLogin.requestBody"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.UserLogin.successResponseBody"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.UserLogin.userNotFoundResponseBody"
                         }
                     }
                 }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -111,6 +111,46 @@
                     }
                 }
             }
+        },
+        "/user/login": {
+            "post": {
+                "description": "Login a user with username and password.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Login a user",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.UserLogin.requestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.UserLogin.successResponseBody"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.UserLogin.userNotFoundResponseBody"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -210,6 +250,48 @@
                 "username": {
                     "type": "string",
                     "example": "username"
+                }
+            }
+        },
+        "controllers.UserLogin.requestBody": {
+            "type": "object",
+            "required": [
+                "password",
+                "username"
+            ],
+            "properties": {
+                "password": {
+                    "type": "string",
+                    "example": "password"
+                },
+                "username": {
+                    "type": "string",
+                    "example": "username"
+                }
+            }
+        },
+        "controllers.UserLogin.successResponseBody": {
+            "type": "object",
+            "properties": {
+                "user": {
+                    "$ref": "#/definitions/controllers.UserDto"
+                }
+            }
+        },
+        "controllers.UserLogin.userNotFoundResponseBody": {
+            "type": "object",
+            "properties": {
+                "msg": {
+                    "type": "string",
+                    "example": "User not found"
+                },
+                "user": {
+                    "description": "Should always be nil.\nTODO: Should be removed; also swaggo fails to generate example with null value.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/controllers.UserDto"
+                        }
+                    ]
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,5 +1,31 @@
 definitions:
-  main.healthResponse:
+  controllers.createDocumentFailedResponse:
+    properties:
+      error:
+        example: Failed to create document
+        type: string
+    type: object
+  controllers.createDocumentInvalidResponse:
+    properties:
+      error:
+        example: Invalid request body
+        type: string
+    type: object
+  controllers.createDocumentRequest:
+    properties:
+      author_id:
+        example: 1
+        type: integer
+    required:
+    - author_id
+    type: object
+  controllers.createDocumentSuccessResponse:
+    properties:
+      document_id:
+        example: 10
+        type: integer
+    type: object
+  router.healthResponse:
     properties:
       message:
         type: string
@@ -7,6 +33,37 @@ definitions:
 info:
   contact: {}
 paths:
+  /document:
+    post:
+      consumes:
+      - application/json
+      description: Create a new document that belongs to the author; the author has
+        to be a existing user.
+      parameters:
+      - description: ' '
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/controllers.createDocumentRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controllers.createDocumentSuccessResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/controllers.createDocumentInvalidResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controllers.createDocumentFailedResponse'
+      summary: Create document
+      tags:
+      - document
   /health:
     get:
       consumes:
@@ -17,7 +74,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/main.healthResponse'
+            $ref: '#/definitions/router.healthResponse'
       summary: Check health
       tags:
       - health

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -67,6 +67,35 @@ definitions:
         example: username
         type: string
     type: object
+  controllers.UserLogin.requestBody:
+    properties:
+      password:
+        example: password
+        type: string
+      username:
+        example: username
+        type: string
+    required:
+    - password
+    - username
+    type: object
+  controllers.UserLogin.successResponseBody:
+    properties:
+      user:
+        $ref: '#/definitions/controllers.UserDto'
+    type: object
+  controllers.UserLogin.userNotFoundResponseBody:
+    properties:
+      msg:
+        example: User not found
+        type: string
+      user:
+        allOf:
+        - $ref: '#/definitions/controllers.UserDto'
+        description: |-
+          Should always be nil.
+          TODO: Should be removed; also swaggo fails to generate example with null value.
+    type: object
   router.CheckHealth.responseBody:
     properties:
       message:
@@ -144,6 +173,32 @@ paths:
           schema:
             $ref: '#/definitions/controllers.UserCreate.existedResponseBody'
       summary: Create a user
+      tags:
+      - User
+  /user/login:
+    post:
+      consumes:
+      - application/json
+      description: Login a user with username and password.
+      parameters:
+      - description: ' '
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/controllers.UserLogin.requestBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controllers.UserLogin.successResponseBody'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/controllers.UserLogin.userNotFoundResponseBody'
+      summary: Login a user
       tags:
       - User
 swagger: "2.0"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -105,7 +105,7 @@ paths:
             $ref: '#/definitions/controllers.CreateDocument.failedResponseBody'
       summary: Create document
       tags:
-      - document
+      - Document
   /health:
     get:
       consumes:
@@ -119,7 +119,7 @@ paths:
             $ref: '#/definitions/router.CheckHealth.responseBody'
       summary: Check health
       tags:
-      - health
+      - Health
   /user/create:
     post:
       consumes:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -25,6 +25,34 @@ definitions:
         example: 10
         type: integer
     type: object
+  controllers.GetUsersByUsername.requestBody:
+    properties:
+      username:
+        example: username
+        type: string
+    required:
+    - username
+    type: object
+  controllers.GetUsersByUsername.successResponseBody:
+    properties:
+      users:
+        items:
+          $ref: '#/definitions/controllers.UserDto'
+        type: array
+    type: object
+  controllers.GetUsersByUsername.usersNotFoundResponseBody:
+    properties:
+      msg:
+        example: Users not found
+        type: string
+      users:
+        description: |-
+          Should always be empty.
+          XXX: Consider removing the field.
+        items:
+          $ref: '#/definitions/controllers.UserDto'
+        type: array
+    type: object
   controllers.UserCreate.existedResponseBody:
     properties:
       msg:
@@ -94,7 +122,7 @@ definitions:
         - $ref: '#/definitions/controllers.UserDto'
         description: |-
           Should always be nil.
-          TODO: Should be removed; also swaggo fails to generate example with null value.
+          XXX: Consider removing the field; also swaggo fails to generate example with null value.
     type: object
   router.CheckHealth.responseBody:
     properties:
@@ -173,6 +201,28 @@ paths:
           schema:
             $ref: '#/definitions/controllers.UserCreate.existedResponseBody'
       summary: Create a user
+      tags:
+      - User
+  /user/get:
+    post:
+      consumes:
+      - application/json
+      description: Get users with the same given username.
+      parameters:
+      - description: ' '
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/controllers.GetUsersByUsername.requestBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controllers.GetUsersByUsername.usersNotFoundResponseBody'
+      summary: Get users by username
       tags:
       - User
   /user/login:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,32 +1,17 @@
 definitions:
-  controllers.UserDto:
-    properties:
-      email:
-        example: email@mail.com
-        type: string
-      id:
-        example: 1
-        type: integer
-      identity:
-        example: user
-        type: string
-      username:
-        example: username
-        type: string
-    type: object
-  controllers.createDocumentFailedResponse:
+  controllers.CreateDocument.failedResponseBody:
     properties:
       error:
         example: Failed to create document
         type: string
     type: object
-  controllers.createDocumentInvalidResponse:
+  controllers.CreateDocument.invalidResponseBody:
     properties:
       error:
         example: Invalid request body
         type: string
     type: object
-  controllers.createDocumentRequest:
+  controllers.CreateDocument.requestBody:
     properties:
       author_id:
         example: 1
@@ -34,19 +19,19 @@ definitions:
     required:
     - author_id
     type: object
-  controllers.createDocumentSuccessResponse:
+  controllers.CreateDocument.successResponseBody:
     properties:
       document_id:
         example: 10
         type: integer
     type: object
-  controllers.userCreateExistedResponse:
+  controllers.UserCreate.existedResponseBody:
     properties:
       msg:
         example: User/Email already exists
         type: string
     type: object
-  controllers.userCreateRequest:
+  controllers.UserCreate.requestBody:
     properties:
       email:
         example: email@mail.com
@@ -62,12 +47,27 @@ definitions:
     - password
     - username
     type: object
-  controllers.userCreateSuccessResponse:
+  controllers.UserCreate.successResponseBody:
     properties:
       user:
         $ref: '#/definitions/controllers.UserDto'
     type: object
-  router.healthResponse:
+  controllers.UserDto:
+    properties:
+      email:
+        example: email@mail.com
+        type: string
+      id:
+        example: 1
+        type: integer
+      identity:
+        example: user
+        type: string
+      username:
+        example: username
+        type: string
+    type: object
+  router.CheckHealth.responseBody:
     properties:
       message:
         type: string
@@ -87,22 +87,22 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/controllers.createDocumentRequest'
+          $ref: '#/definitions/controllers.CreateDocument.requestBody'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/controllers.createDocumentSuccessResponse'
+            $ref: '#/definitions/controllers.CreateDocument.successResponseBody'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/controllers.createDocumentInvalidResponse'
+            $ref: '#/definitions/controllers.CreateDocument.invalidResponseBody'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/controllers.createDocumentFailedResponse'
+            $ref: '#/definitions/controllers.CreateDocument.failedResponseBody'
       summary: Create document
       tags:
       - document
@@ -116,7 +116,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/router.healthResponse'
+            $ref: '#/definitions/router.CheckHealth.responseBody'
       summary: Check health
       tags:
       - health
@@ -131,18 +131,18 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/controllers.userCreateRequest'
+          $ref: '#/definitions/controllers.UserCreate.requestBody'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/controllers.userCreateSuccessResponse'
+            $ref: '#/definitions/controllers.UserCreate.successResponseBody'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/controllers.userCreateExistedResponse'
+            $ref: '#/definitions/controllers.UserCreate.existedResponseBody'
       summary: Create a user
       tags:
       - User

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,4 +1,19 @@
 definitions:
+  controllers.UserDto:
+    properties:
+      email:
+        example: email@mail.com
+        type: string
+      id:
+        example: 1
+        type: integer
+      identity:
+        example: user
+        type: string
+      username:
+        example: username
+        type: string
+    type: object
   controllers.createDocumentFailedResponse:
     properties:
       error:
@@ -24,6 +39,33 @@ definitions:
       document_id:
         example: 10
         type: integer
+    type: object
+  controllers.userCreateExistedResponse:
+    properties:
+      msg:
+        example: User/Email already exists
+        type: string
+    type: object
+  controllers.userCreateRequest:
+    properties:
+      email:
+        example: email@mail.com
+        type: string
+      password:
+        example: password
+        type: string
+      username:
+        example: username
+        type: string
+    required:
+    - email
+    - password
+    - username
+    type: object
+  controllers.userCreateSuccessResponse:
+    properties:
+      user:
+        $ref: '#/definitions/controllers.UserDto'
     type: object
   router.healthResponse:
     properties:
@@ -78,4 +120,30 @@ paths:
       summary: Check health
       tags:
       - health
+  /user/create:
+    post:
+      consumes:
+      - application/json
+      description: Create a new user; the user will be created with the identity "user".
+      parameters:
+      - description: ' '
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/controllers.userCreateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controllers.userCreateSuccessResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/controllers.userCreateExistedResponse'
+      summary: Create a user
+      tags:
+      - User
 swagger: "2.0"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -177,7 +177,33 @@ paths:
       summary: Check health
       tags:
       - Health
-  /user/create:
+  /login:
+    post:
+      consumes:
+      - application/json
+      description: Login a user with username and password.
+      parameters:
+      - description: ' '
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/controllers.UserLogin.requestBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controllers.UserLogin.successResponseBody'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/controllers.UserLogin.userNotFoundResponseBody'
+      summary: Login a user
+      tags:
+      - User
+  /user:
     post:
       consumes:
       - application/json
@@ -203,7 +229,7 @@ paths:
       summary: Create a user
       tags:
       - User
-  /user/get:
+  /users:
     post:
       consumes:
       - application/json
@@ -223,32 +249,6 @@ paths:
           schema:
             $ref: '#/definitions/controllers.GetUsersByUsername.usersNotFoundResponseBody'
       summary: Get users by username
-      tags:
-      - User
-  /user/login:
-    post:
-      consumes:
-      - application/json
-      description: Login a user with username and password.
-      parameters:
-      - description: ' '
-        in: body
-        name: body
-        required: true
-        schema:
-          $ref: '#/definitions/controllers.UserLogin.requestBody'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/controllers.UserLogin.successResponseBody'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/controllers.UserLogin.userNotFoundResponseBody'
-      summary: Login a user
       tags:
       - User
 swagger: "2.0"

--- a/router/router.go
+++ b/router/router.go
@@ -11,18 +11,18 @@ import (
 	ginswagger "github.com/swaggo/gin-swagger" // gin-swagger middleware
 )
 
-type healthResponse struct {
-	Message string `json:"message"`
-}
-
 // @Summary Check health
 // @Tags health
 // @Accept json
 // @Produce json
-// @Success 200 {object} healthResponse
+// @Success 200 {object} router.CheckHealth.responseBody
 // @Router /health [get]
 func CheckHealth(c *gin.Context) {
-	c.JSON(http.StatusOK, healthResponse{
+	type responseBody struct {
+		Message string `json:"message"`
+	}
+
+	c.JSON(http.StatusOK, responseBody{
 		Message: "health check success",
 	})
 }

--- a/router/router.go
+++ b/router/router.go
@@ -12,7 +12,7 @@ import (
 )
 
 // @Summary Check health
-// @Tags health
+// @Tags Health
 // @Accept json
 // @Produce json
 // @Success 200 {object} router.CheckHealth.responseBody

--- a/router/router.go
+++ b/router/router.go
@@ -30,7 +30,7 @@ func CheckHealth(c *gin.Context) {
 func setSwagger(r *gin.Engine) {
 	docs.SwaggerInfo.Title = "Docentre API"
 	docs.SwaggerInfo.Description = "This is the API documentation for Docentre."
-	r.GET("/swagger/*any", ginswagger.WrapHandler(swaggerfiles.Handler))
+	r.GET("/swagger/*any", ginswagger.WrapHandler(swaggerfiles.Handler, ginswagger.DefaultModelsExpandDepth(-1)))
 }
 
 func setHealthCheckController(r *gin.Engine) {


### PR DESCRIPTION
# What's Changed?

Added API documentation for the currently implemented APIs:

- CreateDocument
- UserCreate
- UserLogin
- GetUsersByUsername

The definition of request and response structs is necessary for Swagger to recognize the JSON structure. We need them to annotate the Swagger comment.

This also affects the API implementation, but I believe making the request and response structs explicit has only advantages.

> [!note]
> - Two `XXX` comments are added for JSON fields that are also null/empty in the response body. I suggest removing them in the further pull request as these fields are ill-formed. The front-end is expected to check the status code and not access these fields.
> - The `GetUsersByUsername` endpoint returns `200` even on errors, which seems to be a mistake. If there's no user with the given username, the `users` list is simply empty and no error is returned. The error indicates other kinds of situations.

# How to Verify?

Start the server with `docker compose up` and visit `http://localhost:8080/swagger/index.html`. The documentation of the APIs should be shown properly.