### PR TITLE
implement get documents relates API: GetAuthorDocuments, AddViewer, GetViewerDocuments

### DIFF
--- a/controllers/document_controller.go
+++ b/controllers/document_controller.go
@@ -117,3 +117,179 @@ func UpdateDocument(c *gin.Context) {
 		DocumentID: documentID,
 	})
 }
+
+type docDto struct {
+	ID        uint   `json:"id" example:"1"`
+	AuthorID  uint   `json:"author_id" example:"1"`
+	Title     string `json:"title" example:"Important Document"`
+	Status    string `json:"status" example:"EDIT"`
+	CreatedAt string `json:"created_at" example:"2021-08-01T00:00:00Z"`
+	UpdatedAt string `json:"updated_at" example:"2021-08-01T00:00:00Z"`
+}
+
+// @Summary Get author documents
+// @Description Get all documents that belong to the author; the author has to be a existing user.
+// @Tags Document
+// @Accept json
+// @Produce json
+// @Param body body controllers.GetAuthorDocuments.requestBody true " "
+// @Success 200 {object} controllers.GetAuthorDocuments.successResponseBody
+// @Failure 400 {object} controllers.GetAuthorDocuments.invalidResponseBody
+// @Failure 500 {object} controllers.GetAuthorDocuments.failedResponseBody
+// @Router /documents/author [post]
+func GetAuthorDocuments(c *gin.Context) {
+	type requestBody struct {
+		AuthorID uint `json:"author_id" example:"1"`
+	}
+	type invalidResponseBody struct {
+		Error string `json:"error" example:"Invalid request body"`
+	}
+	type failedResponseBody struct {
+		Error string `json:"error" example:"Failed to get documents"`
+	}
+	type successResponseBody struct {
+		Documents []docDto `json:"documents"`
+	}
+
+	var body requestBody
+	err := c.BindJSON(&body)
+	if err != nil {
+		log.Println(err)
+		c.JSON(http.StatusBadRequest, invalidResponseBody{
+			Error: "Invalid request body",
+		})
+		return
+	}
+
+	docs, err := services.GetAuthorDocuments(body.AuthorID)
+	if err != nil {
+		log.Println(err)
+		c.JSON(http.StatusInternalServerError, failedResponseBody{
+			Error: "Failed to get documents",
+		})
+		return
+	}
+
+	var docsDto []docDto
+
+	for _, doc := range docs {
+		docsDto = append(docsDto, docDto{
+			ID:        doc.ID,
+			AuthorID:  doc.AuthorID,
+			Title:     doc.Title,
+			Status:    doc.Status,
+			CreatedAt: doc.CreatedAt.String(),
+			UpdatedAt: doc.UpdatedAt.String(),
+		})
+	}
+
+	c.JSON(http.StatusOK, successResponseBody{
+		Documents: docsDto,
+	})
+}
+
+// @Summary Get viewer documents
+// @Description Get all documents that belong to the viewer; the viewer has to be a existing user.
+// @Tags Document
+// @Accept json
+// @Produce json
+// @Param body body controllers.GetViewerDocuments.requestBody true " "
+// @Success 200 {object} controllers.GetViewerDocuments.successResponseBody
+// @Failure 400 {object} controllers.GetViewerDocuments.invalidResponseBody
+// @Failure 500 {object} controllers.GetViewerDocuments.failedResponseBody
+// @Router /documents/viewer [post]
+func GetViewerDocuments(c *gin.Context) {
+	type requestBody struct {
+		ViewerID uint `json:"viewer_id" example:"1"`
+	}
+	type invalidResponseBody struct {
+		Error string `json:"error" example:"Invalid request body"`
+	}
+	type failedResponseBody struct {
+		Error string `json:"error" example:"Failed to get documents"`
+	}
+	type successResponseBody struct {
+		Documents []docDto `json:"documents"`
+	}
+
+	var body requestBody
+	err := c.BindJSON(&body)
+	if err != nil {
+		log.Println(err)
+		c.JSON(http.StatusBadRequest, invalidResponseBody{
+			Error: "Invalid request body",
+		})
+		return
+	}
+
+	docs, err := services.GetViewerDocuments(body.ViewerID)
+	if err != nil {
+		log.Println(err)
+		c.JSON(http.StatusInternalServerError, failedResponseBody{
+			Error: "Failed to get documents",
+		})
+		return
+	}
+
+	var docsDto []docDto
+
+	for _, doc := range docs {
+		docsDto = append(docsDto, docDto{
+			ID:        doc.ID,
+			AuthorID:  doc.AuthorID,
+			Title:     doc.Title,
+			Status:    doc.Status,
+			CreatedAt: doc.CreatedAt.String(),
+			UpdatedAt: doc.UpdatedAt.String(),
+		})
+	}
+
+	c.JSON(http.StatusOK, successResponseBody{
+		Documents: docsDto,
+	})
+}
+
+// @Summary Add viewer
+// @Description Add a viewer to the document; the viewer has to be a existing user.
+// @Tags Document
+// @Accept json
+// @Produce json
+// @Param body body controllers.AddViewer.requestBody true " "
+// @Success 200 {object} controllers.AddViewer.successResponseBody
+// @Failure 400 {object} controllers.AddViewer.invalidResponseBody
+// @Failure 500 {object} controllers.AddViewer.failedResponseBody
+// @Router /document/add/viewer [post]
+func AddViewer(c *gin.Context) {
+	type requestBody struct {
+		DocumentID uint `json:"document_id" binding:"required" example:"1"`
+		ViewerID   uint `json:"viewer_id" binding:"required" example:"1"`
+	}
+	type invalidResponseBody struct {
+		Error string `json:"error" example:"Invalid request body"`
+	}
+	type failedResponseBody struct {
+		Error string `json:"error" example:"Failed to add viewer to the document"`
+	}
+	type successResponseBody struct{}
+
+	var body requestBody
+	err := c.BindJSON(&body)
+	if err != nil {
+		log.Println(err)
+		c.JSON(http.StatusBadRequest, invalidResponseBody{
+			Error: "Invalid request body",
+		})
+		return
+	}
+
+	err = services.AddViewer(body.DocumentID, body.ViewerID)
+	if err != nil {
+		log.Println(err)
+		c.JSON(http.StatusInternalServerError, failedResponseBody{
+			Error: "Failed to add viewer to the document",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, successResponseBody{})
+}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -61,6 +61,52 @@ const docTemplate = `{
                 }
             }
         },
+        "/document/add/viewer": {
+            "post": {
+                "description": "Add a viewer to the document; the viewer has to be a existing user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Document"
+                ],
+                "summary": "Add viewer",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.AddViewer.requestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.AddViewer.successResponseBody"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.AddViewer.invalidResponseBody"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.AddViewer.failedResponseBody"
+                        }
+                    }
+                }
+            }
+        },
         "/document/update": {
             "put": {
                 "description": "Update a document that belongs to the author; the author has to be a existing user. if no approver yet, approver_id should be 0.",
@@ -102,6 +148,98 @@ const docTemplate = `{
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/controllers.UpdateDocument.failedResponseBody"
+                        }
+                    }
+                }
+            }
+        },
+        "/documents/author": {
+            "post": {
+                "description": "Get all documents that belong to the author; the author has to be a existing user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Document"
+                ],
+                "summary": "Get author documents",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetAuthorDocuments.requestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetAuthorDocuments.successResponseBody"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetAuthorDocuments.invalidResponseBody"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetAuthorDocuments.failedResponseBody"
+                        }
+                    }
+                }
+            }
+        },
+        "/documents/viewer": {
+            "post": {
+                "description": "Get all documents that belong to the viewer; the viewer has to be a existing user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Document"
+                ],
+                "summary": "Get viewer documents",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetViewerDocuments.requestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetViewerDocuments.successResponseBody"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetViewerDocuments.invalidResponseBody"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetViewerDocuments.failedResponseBody"
                         }
                     }
                 }
@@ -257,6 +395,44 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "controllers.AddViewer.failedResponseBody": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Failed to add viewer to the document"
+                }
+            }
+        },
+        "controllers.AddViewer.invalidResponseBody": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Invalid request body"
+                }
+            }
+        },
+        "controllers.AddViewer.requestBody": {
+            "type": "object",
+            "required": [
+                "document_id",
+                "viewer_id"
+            ],
+            "properties": {
+                "document_id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "viewer_id": {
+                    "type": "integer",
+                    "example": 1
+                }
+            }
+        },
+        "controllers.AddViewer.successResponseBody": {
+            "type": "object"
+        },
         "controllers.CreateDocument.failedResponseBody": {
             "type": "object",
             "properties": {
@@ -296,6 +472,44 @@ const docTemplate = `{
                 }
             }
         },
+        "controllers.GetAuthorDocuments.failedResponseBody": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Failed to get documents"
+                }
+            }
+        },
+        "controllers.GetAuthorDocuments.invalidResponseBody": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Invalid request body"
+                }
+            }
+        },
+        "controllers.GetAuthorDocuments.requestBody": {
+            "type": "object",
+            "properties": {
+                "author_id": {
+                    "type": "integer",
+                    "example": 1
+                }
+            }
+        },
+        "controllers.GetAuthorDocuments.successResponseBody": {
+            "type": "object",
+            "properties": {
+                "documents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.docDto"
+                    }
+                }
+            }
+        },
         "controllers.GetUsersByUsername.requestBody": {
             "type": "object",
             "required": [
@@ -331,6 +545,44 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/controllers.UserDto"
+                    }
+                }
+            }
+        },
+        "controllers.GetViewerDocuments.failedResponseBody": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Failed to get documents"
+                }
+            }
+        },
+        "controllers.GetViewerDocuments.invalidResponseBody": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Invalid request body"
+                }
+            }
+        },
+        "controllers.GetViewerDocuments.requestBody": {
+            "type": "object",
+            "properties": {
+                "viewer_id": {
+                    "type": "integer",
+                    "example": 1
+                }
+            }
+        },
+        "controllers.GetViewerDocuments.successResponseBody": {
+            "type": "object",
+            "properties": {
+                "documents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.docDto"
                     }
                 }
             }
@@ -499,6 +751,35 @@ const docTemplate = `{
                             "$ref": "#/definitions/controllers.UserDto"
                         }
                     ]
+                }
+            }
+        },
+        "controllers.docDto": {
+            "type": "object",
+            "properties": {
+                "author_id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2021-08-01T00:00:00Z"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "status": {
+                    "type": "string",
+                    "example": "EDIT"
+                },
+                "title": {
+                    "type": "string",
+                    "example": "Important Document"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2021-08-01T00:00:00Z"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -50,6 +50,52 @@
                 }
             }
         },
+        "/document/add/viewer": {
+            "post": {
+                "description": "Add a viewer to the document; the viewer has to be a existing user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Document"
+                ],
+                "summary": "Add viewer",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.AddViewer.requestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.AddViewer.successResponseBody"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.AddViewer.invalidResponseBody"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.AddViewer.failedResponseBody"
+                        }
+                    }
+                }
+            }
+        },
         "/document/update": {
             "put": {
                 "description": "Update a document that belongs to the author; the author has to be a existing user. if no approver yet, approver_id should be 0.",
@@ -91,6 +137,98 @@
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/controllers.UpdateDocument.failedResponseBody"
+                        }
+                    }
+                }
+            }
+        },
+        "/documents/author": {
+            "post": {
+                "description": "Get all documents that belong to the author; the author has to be a existing user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Document"
+                ],
+                "summary": "Get author documents",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetAuthorDocuments.requestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetAuthorDocuments.successResponseBody"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetAuthorDocuments.invalidResponseBody"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetAuthorDocuments.failedResponseBody"
+                        }
+                    }
+                }
+            }
+        },
+        "/documents/viewer": {
+            "post": {
+                "description": "Get all documents that belong to the viewer; the viewer has to be a existing user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Document"
+                ],
+                "summary": "Get viewer documents",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetViewerDocuments.requestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetViewerDocuments.successResponseBody"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetViewerDocuments.invalidResponseBody"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetViewerDocuments.failedResponseBody"
                         }
                     }
                 }
@@ -246,6 +384,44 @@
         }
     },
     "definitions": {
+        "controllers.AddViewer.failedResponseBody": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Failed to add viewer to the document"
+                }
+            }
+        },
+        "controllers.AddViewer.invalidResponseBody": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Invalid request body"
+                }
+            }
+        },
+        "controllers.AddViewer.requestBody": {
+            "type": "object",
+            "required": [
+                "document_id",
+                "viewer_id"
+            ],
+            "properties": {
+                "document_id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "viewer_id": {
+                    "type": "integer",
+                    "example": 1
+                }
+            }
+        },
+        "controllers.AddViewer.successResponseBody": {
+            "type": "object"
+        },
         "controllers.CreateDocument.failedResponseBody": {
             "type": "object",
             "properties": {
@@ -285,6 +461,44 @@
                 }
             }
         },
+        "controllers.GetAuthorDocuments.failedResponseBody": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Failed to get documents"
+                }
+            }
+        },
+        "controllers.GetAuthorDocuments.invalidResponseBody": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Invalid request body"
+                }
+            }
+        },
+        "controllers.GetAuthorDocuments.requestBody": {
+            "type": "object",
+            "properties": {
+                "author_id": {
+                    "type": "integer",
+                    "example": 1
+                }
+            }
+        },
+        "controllers.GetAuthorDocuments.successResponseBody": {
+            "type": "object",
+            "properties": {
+                "documents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.docDto"
+                    }
+                }
+            }
+        },
         "controllers.GetUsersByUsername.requestBody": {
             "type": "object",
             "required": [
@@ -320,6 +534,44 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/controllers.UserDto"
+                    }
+                }
+            }
+        },
+        "controllers.GetViewerDocuments.failedResponseBody": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Failed to get documents"
+                }
+            }
+        },
+        "controllers.GetViewerDocuments.invalidResponseBody": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Invalid request body"
+                }
+            }
+        },
+        "controllers.GetViewerDocuments.requestBody": {
+            "type": "object",
+            "properties": {
+                "viewer_id": {
+                    "type": "integer",
+                    "example": 1
+                }
+            }
+        },
+        "controllers.GetViewerDocuments.successResponseBody": {
+            "type": "object",
+            "properties": {
+                "documents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.docDto"
                     }
                 }
             }
@@ -488,6 +740,35 @@
                             "$ref": "#/definitions/controllers.UserDto"
                         }
                     ]
+                }
+            }
+        },
+        "controllers.docDto": {
+            "type": "object",
+            "properties": {
+                "author_id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2021-08-01T00:00:00Z"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "status": {
+                    "type": "string",
+                    "example": "EDIT"
+                },
+                "title": {
+                    "type": "string",
+                    "example": "Important Document"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2021-08-01T00:00:00Z"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,4 +1,30 @@
 definitions:
+  controllers.AddViewer.failedResponseBody:
+    properties:
+      error:
+        example: Failed to add viewer to the document
+        type: string
+    type: object
+  controllers.AddViewer.invalidResponseBody:
+    properties:
+      error:
+        example: Invalid request body
+        type: string
+    type: object
+  controllers.AddViewer.requestBody:
+    properties:
+      document_id:
+        example: 1
+        type: integer
+      viewer_id:
+        example: 1
+        type: integer
+    required:
+    - document_id
+    - viewer_id
+    type: object
+  controllers.AddViewer.successResponseBody:
+    type: object
   controllers.CreateDocument.failedResponseBody:
     properties:
       error:
@@ -24,6 +50,31 @@ definitions:
       document_id:
         example: 1
         type: integer
+    type: object
+  controllers.GetAuthorDocuments.failedResponseBody:
+    properties:
+      error:
+        example: Failed to get documents
+        type: string
+    type: object
+  controllers.GetAuthorDocuments.invalidResponseBody:
+    properties:
+      error:
+        example: Invalid request body
+        type: string
+    type: object
+  controllers.GetAuthorDocuments.requestBody:
+    properties:
+      author_id:
+        example: 1
+        type: integer
+    type: object
+  controllers.GetAuthorDocuments.successResponseBody:
+    properties:
+      documents:
+        items:
+          $ref: '#/definitions/controllers.docDto'
+        type: array
     type: object
   controllers.GetUsersByUsername.requestBody:
     properties:
@@ -51,6 +102,31 @@ definitions:
           XXX: Consider removing the field.
         items:
           $ref: '#/definitions/controllers.UserDto'
+        type: array
+    type: object
+  controllers.GetViewerDocuments.failedResponseBody:
+    properties:
+      error:
+        example: Failed to get documents
+        type: string
+    type: object
+  controllers.GetViewerDocuments.invalidResponseBody:
+    properties:
+      error:
+        example: Invalid request body
+        type: string
+    type: object
+  controllers.GetViewerDocuments.requestBody:
+    properties:
+      viewer_id:
+        example: 1
+        type: integer
+    type: object
+  controllers.GetViewerDocuments.successResponseBody:
+    properties:
+      documents:
+        items:
+          $ref: '#/definitions/controllers.docDto'
         type: array
     type: object
   controllers.UpdateDocument.failedResponseBody:
@@ -170,6 +246,27 @@ definitions:
           Should always be nil.
           XXX: Consider removing the field; also swaggo fails to generate example with null value.
     type: object
+  controllers.docDto:
+    properties:
+      author_id:
+        example: 1
+        type: integer
+      created_at:
+        example: "2021-08-01T00:00:00Z"
+        type: string
+      id:
+        example: 1
+        type: integer
+      status:
+        example: EDIT
+        type: string
+      title:
+        example: Important Document
+        type: string
+      updated_at:
+        example: "2021-08-01T00:00:00Z"
+        type: string
+    type: object
   controllers.invalidResponseBody:
     properties:
       msg:
@@ -215,6 +312,36 @@ paths:
       summary: Create document
       tags:
       - Document
+  /document/add/viewer:
+    post:
+      consumes:
+      - application/json
+      description: Add a viewer to the document; the viewer has to be a existing user.
+      parameters:
+      - description: ' '
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/controllers.AddViewer.requestBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controllers.AddViewer.successResponseBody'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/controllers.AddViewer.invalidResponseBody'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controllers.AddViewer.failedResponseBody'
+      summary: Add viewer
+      tags:
+      - Document
   /document/update:
     put:
       consumes:
@@ -244,6 +371,68 @@ paths:
           schema:
             $ref: '#/definitions/controllers.UpdateDocument.failedResponseBody'
       summary: Update document
+      tags:
+      - Document
+  /documents/author:
+    post:
+      consumes:
+      - application/json
+      description: Get all documents that belong to the author; the author has to
+        be a existing user.
+      parameters:
+      - description: ' '
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/controllers.GetAuthorDocuments.requestBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controllers.GetAuthorDocuments.successResponseBody'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/controllers.GetAuthorDocuments.invalidResponseBody'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controllers.GetAuthorDocuments.failedResponseBody'
+      summary: Get author documents
+      tags:
+      - Document
+  /documents/viewer:
+    post:
+      consumes:
+      - application/json
+      description: Get all documents that belong to the viewer; the viewer has to
+        be a existing user.
+      parameters:
+      - description: ' '
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/controllers.GetViewerDocuments.requestBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controllers.GetViewerDocuments.successResponseBody'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/controllers.GetViewerDocuments.invalidResponseBody'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controllers.GetViewerDocuments.failedResponseBody'
+      summary: Get viewer documents
       tags:
       - Document
   /health:

--- a/models/models.go
+++ b/models/models.go
@@ -12,20 +12,27 @@ type User struct {
 }
 
 type Document struct {
-	ID           uint `gorm:"primaryKey"`
-	AuthorID     uint
-	Title        string
-	Content      string
-	Appendix     string
-	Status       string `gorm:"not null;default:'EDIT'"` // EDIT, VERIFY, REJECT, APPROVE
-	RejectReason string
+	ID       uint `gorm:"primaryKey"`
+	AuthorID uint
+	Title    string
+	Content  string
+	Appendix string
+	Status   string `gorm:"not null;default:'EDIT'"` // EDIT, VERIFY, REJECT, APPROVE
+	// RejectReason string // should be in history table
 	CreatedAt    time.Time // 建立時間（由GORM自動管理）
 	UpdatedAt    time.Time // 最後一次更新時間（由GORM自動管理）
 	ApprovedDate time.Time
 	// foreign keys to User
 	ApproverID uint `gorm:"foreignKey:ApproverID"`
-	ViewerID   uint `gorm:"foreignKey:ViewerID"`
 	Author     User `gorm:"constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
 	Approver   User `gorm:"constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
-	Viewer     User `gorm:"constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
+}
+
+type DocumentViewer struct {
+	ID uint `gorm:"primaryKey"`
+	// foreign keys to Document and User
+	DocumentID uint     `gorm:"foreignKey:DocumentID"`
+	ViewerID   uint     `gorm:"foreignKey:ViewerID"`
+	Document   Document `gorm:"constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
+	Viewer     User     `gorm:"constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
 }

--- a/repositories/database.go
+++ b/repositories/database.go
@@ -24,4 +24,5 @@ func ConnectToDB(dialector gorm.Dialector, config *gorm.Config) {
 func MigrateDB() {
 	DB.AutoMigrate(&models.User{})
 	DB.AutoMigrate(&models.Document{})
+	DB.AutoMigrate(&models.DocumentViewer{})
 }

--- a/router/router.go
+++ b/router/router.go
@@ -46,6 +46,9 @@ func setUserController(r *gin.Engine) {
 func setDocumentController(r *gin.Engine) {
 	r.POST("/document", controllers.CreateDocument)
 	r.PUT("/document/update", controllers.UpdateDocument)
+	r.POST("/document/add/viewer", controllers.AddViewer)
+	r.POST("/documents/author", controllers.GetAuthorDocuments)
+	r.POST("/documents/viewer", controllers.GetViewerDocuments)
 	// TODO r.PATCH("/documents/:document_id/status", controllers.SetDocumentStatus)
 }
 

--- a/services/document_service.go
+++ b/services/document_service.go
@@ -43,3 +43,38 @@ func UpdateDocument(doc UpdateDocumentSnapshot) (uint, error) {
 	}
 	return doc.DocumentID, nil
 }
+
+func GetAuthorDocuments(authorID uint) ([]models.Document, error) {
+	var docs []models.Document
+
+	result := repositories.DB.Where("author_id = ?", authorID).Find(&docs)
+
+	if result.Error != nil {
+		return []models.Document{}, result.Error
+	}
+
+	return docs, nil
+}
+
+func GetViewerDocuments(viewerID uint) ([]models.Document, error) {
+	var docs []models.Document
+
+	result := repositories.DB.Joins("JOIN document_viewers ON documents.id = document_viewers.document_id").Where("viewer_id = ?", viewerID).Find(&docs)
+
+	if result.Error != nil {
+		return []models.Document{}, result.Error
+	}
+
+	return docs, nil
+}
+
+func AddViewer(documentID, viewerID uint) error {
+	docViewer := models.DocumentViewer{DocumentID: documentID, ViewerID: viewerID}
+	result := repositories.DB.Create(&docViewer)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Feature Change
- remove `viewerID` in Document table
    - `viewerID` should be recorded in a separate table since there could be multiple viewers in a document
- add `document_viewer` table

### GetAuthorDocuments API

endpoint:  [POST] `http://localhost:8080/documents/author`

### AddViewer API

endpoint:  [POST] `http://localhost:8080/document/add/viewer`

### GetViewerDocuments API

endpoint:  [POST] `http://localhost:8080/documents/viewer`

### Present database diagram
<img width="441" alt="image" src="https://github.com/DoCentre/DoCentre/assets/52515354/f9297196-384c-4a2f-8aa9-e438e9fb9ead">
