### PR TITLE
Get document histories

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -107,6 +107,52 @@ const docTemplate = `{
                 }
             }
         },
+        "/document/histories": {
+            "post": {
+                "description": "Get all histories of the document; the document has to exist, and the user has to have permission to view such document.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Document"
+                ],
+                "summary": "Get document histories",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetDocumentHistories.requestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetDocumentHistories.successResponseBody"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetDocumentHistories.invalidResponseBody"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetDocumentHistories.failedResponseBody"
+                        }
+                    }
+                }
+            }
+        },
         "/document/update": {
             "put": {
                 "description": "Update a document that belongs to the author; the author has to be a existing user. if no approver yet, approver_id should be 0.",
@@ -562,6 +608,52 @@ const docTemplate = `{
                 }
             }
         },
+        "controllers.GetDocumentHistories.failedResponseBody": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Failed to get document history"
+                }
+            }
+        },
+        "controllers.GetDocumentHistories.invalidResponseBody": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Invalid request body"
+                }
+            }
+        },
+        "controllers.GetDocumentHistories.requestBody": {
+            "type": "object",
+            "required": [
+                "document_id",
+                "user_id"
+            ],
+            "properties": {
+                "document_id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "user_id": {
+                    "type": "integer",
+                    "example": 1
+                }
+            }
+        },
+        "controllers.GetDocumentHistories.successResponseBody": {
+            "type": "object",
+            "properties": {
+                "histories": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.historyDto"
+                    }
+                }
+            }
+        },
         "controllers.GetUsersByUsername.requestBody": {
             "type": "object",
             "required": [
@@ -864,6 +956,23 @@ const docTemplate = `{
                 "updated_at": {
                     "type": "string",
                     "example": "2021-08-01T00:00:00Z"
+                }
+            }
+        },
+        "controllers.historyDto": {
+            "type": "object",
+            "properties": {
+                "comment": {
+                    "type": "string",
+                    "example": "It looks bad :("
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2021-08-01T00:00:00Z"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "EDIT"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -96,6 +96,52 @@
                 }
             }
         },
+        "/document/histories": {
+            "post": {
+                "description": "Get all histories of the document; the document has to exist, and the user has to have permission to view such document.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Document"
+                ],
+                "summary": "Get document histories",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetDocumentHistories.requestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetDocumentHistories.successResponseBody"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetDocumentHistories.invalidResponseBody"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.GetDocumentHistories.failedResponseBody"
+                        }
+                    }
+                }
+            }
+        },
         "/document/update": {
             "put": {
                 "description": "Update a document that belongs to the author; the author has to be a existing user. if no approver yet, approver_id should be 0.",
@@ -551,6 +597,52 @@
                 }
             }
         },
+        "controllers.GetDocumentHistories.failedResponseBody": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Failed to get document history"
+                }
+            }
+        },
+        "controllers.GetDocumentHistories.invalidResponseBody": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Invalid request body"
+                }
+            }
+        },
+        "controllers.GetDocumentHistories.requestBody": {
+            "type": "object",
+            "required": [
+                "document_id",
+                "user_id"
+            ],
+            "properties": {
+                "document_id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "user_id": {
+                    "type": "integer",
+                    "example": 1
+                }
+            }
+        },
+        "controllers.GetDocumentHistories.successResponseBody": {
+            "type": "object",
+            "properties": {
+                "histories": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controllers.historyDto"
+                    }
+                }
+            }
+        },
         "controllers.GetUsersByUsername.requestBody": {
             "type": "object",
             "required": [
@@ -853,6 +945,23 @@
                 "updated_at": {
                     "type": "string",
                     "example": "2021-08-01T00:00:00Z"
+                }
+            }
+        },
+        "controllers.historyDto": {
+            "type": "object",
+            "properties": {
+                "comment": {
+                    "type": "string",
+                    "example": "It looks bad :("
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2021-08-01T00:00:00Z"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "EDIT"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -76,6 +76,37 @@ definitions:
           $ref: '#/definitions/controllers.docDto'
         type: array
     type: object
+  controllers.GetDocumentHistories.failedResponseBody:
+    properties:
+      error:
+        example: Failed to get document history
+        type: string
+    type: object
+  controllers.GetDocumentHistories.invalidResponseBody:
+    properties:
+      error:
+        example: Invalid request body
+        type: string
+    type: object
+  controllers.GetDocumentHistories.requestBody:
+    properties:
+      document_id:
+        example: 1
+        type: integer
+      user_id:
+        example: 1
+        type: integer
+    required:
+    - document_id
+    - user_id
+    type: object
+  controllers.GetDocumentHistories.successResponseBody:
+    properties:
+      histories:
+        items:
+          $ref: '#/definitions/controllers.historyDto'
+        type: array
+    type: object
   controllers.GetUsersByUsername.requestBody:
     properties:
       username:
@@ -287,6 +318,18 @@ definitions:
         example: "2021-08-01T00:00:00Z"
         type: string
     type: object
+  controllers.historyDto:
+    properties:
+      comment:
+        example: It looks bad :(
+        type: string
+      created_at:
+        example: "2021-08-01T00:00:00Z"
+        type: string
+      status:
+        example: EDIT
+        type: string
+    type: object
   controllers.invalidResponseBody:
     properties:
       msg:
@@ -360,6 +403,37 @@ paths:
           schema:
             $ref: '#/definitions/controllers.AddViewer.failedResponseBody'
       summary: Add viewer
+      tags:
+      - Document
+  /document/histories:
+    post:
+      consumes:
+      - application/json
+      description: Get all histories of the document; the document has to exist, and
+        the user has to have permission to view such document.
+      parameters:
+      - description: ' '
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/controllers.GetDocumentHistories.requestBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/controllers.GetDocumentHistories.successResponseBody'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/controllers.GetDocumentHistories.invalidResponseBody'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controllers.GetDocumentHistories.failedResponseBody'
+      summary: Get document histories
       tags:
       - Document
   /document/update:

--- a/router/router.go
+++ b/router/router.go
@@ -50,6 +50,7 @@ func setDocumentController(r *gin.Engine) {
 	r.POST("/documents/author", controllers.GetAuthorDocuments)
 	r.POST("/documents/viewer", controllers.GetViewerDocuments)
 	r.PUT("/document/update/status", controllers.SetDocumentStatus)
+	r.POST("/document/histories", controllers.GetDocumentHistories)
 }
 
 func SetupRouter() *gin.Engine {


### PR DESCRIPTION
A single history contains the status that's changed to, along with the associated comment and the time such history is created. For the request to be successful, the document has to exist, and the user has to have permission to view such document.