### PR TITLE
Send email when status is set to approve

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-PORT=8080
-DB_URL="my_user:my_password@tcp(127.0.0.1:3306)/docentre?charset=utf8mb4&parseTime=True&loc=Local"

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,16 @@
+PORT=8080
+DB_URL="my_user:my_password@tcp(127.0.0.1:3306)/docentre?charset=utf8mb4&parseTime=True&loc=Local"
+
+#
+# Email Service
+#
+
+SMTP_HOST="smtp.gmail.com"
+# the TLS port for Gmail
+SMTP_PORT=587
+# the email of the sender
+EMAIL_SENDER=""
+# a 16-digit passcode for Google App Password
+EMAIL_PASSWORD=""
+# a format string template; %d is replaced with the document ID
+DOC_URL_TMPL="http://localhost:8080/approveDoc/%d"

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ docentre
 
 .idea/
 .vscode/
+
+.env

--- a/README.md
+++ b/README.md
@@ -57,7 +57,15 @@ $ cd DoCentre
 $ cd DoCentre-main
 ```
 
-3. Run the containers:
+3. Copy the `.env.sample` file to `.env`:
+
+```console
+$ cp .env.sample .env
+```
+
+4. Fill in the environment variables in the `.env` file.
+
+5. Run the containers:
 
 ```console
 $ docker compose up

--- a/controllers/document_controller.go
+++ b/controllers/document_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"errors"
 	"log"
 	"net/http"
 
@@ -106,7 +107,10 @@ func UpdateDocument(c *gin.Context) {
 		Status:     body.Status,
 		ApproverID: body.ApproverID,
 	})
-	if err != nil {
+	// NOTE: A failed email sending does not affect the status change.
+	if errors.As(err, &services.EmailSendingError{}) {
+		log.Println(err)
+	} else if err != nil {
 		log.Println(err)
 		c.JSON(http.StatusInternalServerError, failedResponseBody{
 			Error: "Failed to update document",

--- a/controllers/document_controller.go
+++ b/controllers/document_controller.go
@@ -371,7 +371,7 @@ func SetDocumentStatus(c *gin.Context) {
 		DocumentID uint   `json:"document_id" binding:"required" example:"1"`
 		AppoverID  uint   `json:"approver_id" example:"1"`
 		Status     string `json:"status" binding:"required" example:"REJECT"`
-		Commnet    string `json:"comment" binding:"required" example:"It looks bad :("`
+		Comment    string `json:"comment" binding:"required" example:"It looks bad :("`
 	}
 	type invalidResponseBody struct {
 		Error string `json:"error" example:"Invalid request body"`
@@ -391,7 +391,7 @@ func SetDocumentStatus(c *gin.Context) {
 		return
 	}
 
-	err = services.SetDocumentStatus(body.DocumentID, body.Status, body.AppoverID, body.Commnet)
+	err = services.SetDocumentStatus(body.DocumentID, body.Status, body.AppoverID, body.Comment)
 	if err != nil {
 		log.Println(err)
 		c.JSON(http.StatusInternalServerError, failedResponseBody{

--- a/services/mail_service.go
+++ b/services/mail_service.go
@@ -1,0 +1,108 @@
+package services
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net/smtp"
+	"os"
+
+	"github.com/docentre/docentre/models"
+	"github.com/docentre/docentre/repositories"
+)
+
+type Config struct {
+	Host       string
+	Port       string
+	Sender     string
+	Password   string
+	DocUrlTmpl string
+}
+
+func loadConfig() (Config, error) {
+	var config Config
+	fields := []*string{&config.Host, &config.Port, &config.Sender, &config.Password, &config.DocUrlTmpl}
+	fieldNames := []string{"SMTP_HOST", "SMTP_PORT", "EMAIL_SENDER", "EMAIL_PASSWORD", "DOC_URL_TMPL"}
+	for i, field := range fields {
+		var ext bool
+		*field, ext = os.LookupEnv(fieldNames[i])
+		if !ext {
+			return Config{}, fmt.Errorf("missing environment variable %s", fieldNames[i])
+		}
+	}
+	return config, nil
+}
+
+func getEmailOf(userID uint) (string, error) {
+	var user models.User
+	if err := repositories.DB.First(&user, userID).Error; err != nil {
+		return "", err
+	}
+	return user.Email, nil
+}
+
+func sendEmailToApprover(documentID uint, approverID uint) error {
+	config, err := loadConfig()
+	if err != nil {
+		return err
+	}
+
+	addr := fmt.Sprintf("%s:%s", config.Host, config.Port)
+	log.Printf("Connecting to the remote SMTP server %s...\n", addr)
+	client, err := smtp.Dial(addr)
+	if err != nil {
+		return err
+	}
+
+	tlsConfig := tls.Config{
+		InsecureSkipVerify: true,
+		ServerName:         config.Host,
+	}
+	log.Println("Sending the STARTTLS command and encrypting all further communication...")
+	if err := client.StartTLS(&tlsConfig); err != nil {
+		return err
+	}
+	auth := smtp.PlainAuth("", config.Sender, config.Password, config.Host)
+	if err := client.Auth(auth); err != nil {
+		return err
+	}
+
+	log.Println("Setting the sender and recipient...")
+	if err := client.Mail(config.Sender); err != nil {
+		return err
+	}
+	rcpt, err := getEmailOf(approverID)
+	if err != nil {
+		return err
+	}
+	if err := client.Rcpt(rcpt); err != nil {
+		return err
+	}
+
+	log.Println("Setting the email content...")
+	wc, err := client.Data()
+	if err != nil {
+		return err
+	}
+	subject := "[DoCentre] Document Approval Request"
+	header := fmt.Sprintf(
+		"To: %s\r\nFrom: %s\r\nSubject: %s\r\n\r\n",
+		rcpt, config.Sender, subject)
+	contentTmpl := "You're assigned as an approver of the document %s, please review it."
+	url := fmt.Sprintf(config.DocUrlTmpl, documentID)
+	content := fmt.Sprintf(contentTmpl, url)
+	if _, err = fmt.Fprintf(wc, header+content); err != nil {
+		return err
+	}
+	if err := wc.Close(); err != nil {
+		return err
+	}
+
+	log.Println("Sending the QUIT command and closing the connection...")
+	if err := client.Quit(); err != nil {
+		return err
+	}
+
+	log.Println("Email sent successfully!")
+	return nil
+}


### PR DESCRIPTION
- The back-end service now sends an email when the `status` is set to `APPROVE` through the `/document/update` endpoint.
- The configurations are managed through the `.env` file.
- The email sending service is considered an add-on. Therefore, an error in sending the email does not fail the status change, and a `200` status code is returned.

/cc @AU2A 
The `.env` file must be set up properly for the service to work.