### PR TITLE
ci: separate docker and k8s deployment into distinct jobs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: Deploy Docker Image
+name: Deploy
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  deploy:
+  docker:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -17,6 +17,13 @@ jobs:
         run: |
           docker build -f Dockerfile.prod -t ghcr.io/docentre/docentre-backend .
           docker push ghcr.io/docentre/docentre-backend
+
+  k8s:
+    runs-on: ubuntu-latest
+    needs: docker
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Load kubeconfig
         run: |-
@@ -33,7 +40,7 @@ jobs:
         run: |-
           kubectl delete -f deploy-backend.yaml
 
-      - name: Start k8s
+      - name: Apply new k8s
         if: always()
         working-directory: ./k8s
         run: |-


### PR DESCRIPTION
I would like to show that we built and deployed the Docker images, and then re-applied the k8s configuration to pull the new images, so they are deployed to our machines.
Without this separation, they are shown as a single job in the history of GitHub Actions.